### PR TITLE
ESLint configuration fix to support both UNIX and WINDOWS line-endings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const os = require('os');
+
 module.exports = {
   root: true,
   extends: 'airbnb-base',
@@ -14,7 +16,7 @@ module.exports = {
 
   // current deviations from AirBnB setup (TODO: revisit later)
   rules: {
-    'linebreak-style': ['warn', 'unix'],
+    'linebreak-style': ['warn', os.EOL === '\n'? 'unix' : 'windows'],
     'no-param-reassign': 0,
     'no-underscore-dangle': ['warn', { 'allowAfterThis': true }],
     'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+[core]
+autocrlf=true


### PR DESCRIPTION
## General idea

Currently ESLint config enforces UNIX style line-endings. That causes thousands of warnings when building solution using Windows. This Pull Request introduces platform independant approach:
Force GIT to handle line-endings natively for each client platform
Make ESLint check that all line-endings are in the same notation

## Changes summary
**.gitattributes** - Added configuration that enables the conversion of CRLF to LF and backward by GIT client
 
**.eslintrc.js** - changed the method of EOL style selecting