### PR TITLE
ValidateConnection method fixed to prevent multiple links into single input port.

### DIFF
--- a/src/pipeline.scss
+++ b/src/pipeline.scss
@@ -18,6 +18,8 @@ $light-gray: #ccc;
 // Semantic color mapping
 $step-color: $sharp-blue;
 $port-color: $graphite;
+$port-color-empty: $dark-blue;
+$port-color-available: $lime-green;
 
 .joint-type-visualstep.selected {
   .body {
@@ -52,6 +54,16 @@ $port-color: $graphite;
     stroke: $white;
     stroke-width: 3px;
     fill: $port-color;
+  }
+
+  .port-body-empty {
+    stroke: $port-color-empty;
+    stroke-width: 1.5px;
+    fill: $white;
+  }
+
+  .available-magnet {
+    fill: $port-color-available;
   }
 
   .port-body:hover {

--- a/src/visual/Paper.js
+++ b/src/visual/Paper.js
@@ -43,12 +43,16 @@ export default class Paper extends joint.dia.Paper {
           return false;
         }
         // source
-        if (!magnetS || magnetS.getAttribute('class') !== 'port-body' ||
+        if (!magnetS || (magnetS.getAttribute('class') !== 'port-body' &&
+          magnetS.getAttribute('class') !== 'port-body-empty' &&
+          magnetS.getAttribute('class') !== 'port-body-empty available-magnet') ||
           magnetS.getAttribute('port-group') !== 'out') {
           return false;
         }
         // target
-        if (!magnetT || magnetT.getAttribute('class') !== 'port-body' ||
+        if (!magnetT || (magnetT.getAttribute('class') !== 'port-body' &&
+          magnetT.getAttribute('class') !== 'port-body-empty' &&
+          magnetT.getAttribute('class') !== 'port-body-empty available-magnet') ||
           magnetT.getAttribute('port-group') !== 'in') {
           return false;
         }
@@ -61,6 +65,7 @@ export default class Paper extends joint.dia.Paper {
 
         return !portUsed;
       },
+      markAvailable: true,
     }));
   }
 

--- a/src/visual/Paper.js
+++ b/src/visual/Paper.js
@@ -42,17 +42,30 @@ export default class Paper extends joint.dia.Paper {
         if (!cellViewT || !cellViewS || cellViewT.id === cellViewS.id) {
           return false;
         }
+
+        const isSuitablePortClass = (magnet) => {
+          const availableClasses = [
+            'port-body',
+            'port-body-empty',
+            'available-magnet',
+          ];
+
+          let result = true;
+          const portClasses = magnet.getAttribute('class').split(/\s+/);
+
+          _.forEach(portClasses, (portClass) => {
+            result = result && (availableClasses.indexOf(portClass) >= 0);
+          });
+
+          return result;
+        };
         // source
-        if (!magnetS || (magnetS.getAttribute('class') !== 'port-body' &&
-          magnetS.getAttribute('class') !== 'port-body-empty' &&
-          magnetS.getAttribute('class') !== 'port-body-empty available-magnet') ||
+        if (!magnetS || !isSuitablePortClass(magnetS) ||
           magnetS.getAttribute('port-group') !== 'out') {
           return false;
         }
         // target
-        if (!magnetT || (magnetT.getAttribute('class') !== 'port-body' &&
-          magnetT.getAttribute('class') !== 'port-body-empty' &&
-          magnetT.getAttribute('class') !== 'port-body-empty available-magnet') ||
+        if (!magnetT || !isSuitablePortClass(magnetT) ||
           magnetT.getAttribute('port-group') !== 'in') {
           return false;
         }

--- a/src/visual/VisualStep.js
+++ b/src/visual/VisualStep.js
@@ -56,14 +56,9 @@ export default class VisualStep extends joint.shapes.devs.Model {
     const ports = this.getPorts();
 
     _.forEach(ports, (port) => {
-      let isEmpty = true;
-      if (port.group === 'in') {
-        isEmpty = isEmpty && (_.size(step.i[port.id].inputs) === 0 && _.size(step.i[port.id].outputs) === 0);
-      }
+      const stepPort = port.group === 'in' ? step.i[port.id] : step.o[port.id];
 
-      if (port.group === 'out') {
-        isEmpty = isEmpty && (_.size(step.o[port.id].inputs) === 0 && _.size(step.o[port.id].outputs) === 0);
-      }
+      const isEmpty = (_.size(stepPort.inputs) + _.size(stepPort.outputs)) === 0;
 
       const propVal = this.portProp(port.id, 'attrs/circle/class');
       const newVal = isEmpty ? 'port-body-empty' : 'port-body';

--- a/src/visual/VisualStep.js
+++ b/src/visual/VisualStep.js
@@ -52,6 +52,25 @@ export default class VisualStep extends joint.shapes.devs.Model {
     this.attr('.label', {
       text: step.name,
     });
+
+    const ports = this.getPorts();
+
+    _.forEach(ports, (port) => {
+      let isEmpty = true;
+      if (port.group === 'in') {
+        isEmpty = isEmpty && (_.size(step.i[port.id].inputs) === 0 && _.size(step.i[port.id].outputs) === 0);
+      }
+
+      if (port.group === 'out') {
+        isEmpty = isEmpty && (_.size(step.o[port.id].inputs) === 0 && _.size(step.o[port.id].outputs) === 0);
+      }
+
+      const propVal = this.portProp(port.id, 'attrs/circle/class');
+      const newVal = isEmpty ? 'port-body-empty' : 'port-body';
+      if (!propVal || newVal !== propVal) {
+        this.portProp(port.id, 'attrs/circle/class', newVal);
+      }
+    });
   }
 
   /**

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -92,7 +92,7 @@ export default class Visualizer {
     this.paper.options.validateConnection = (cellViewS, magnetS, cellViewT, magnetT, end, linkView) => {
       const args = [cellViewS, magnetS, cellViewT, magnetT, end, linkView];
 
-      if (this.paperDefaultValidateConnectionMethod.call(this.paper, ...args)) {
+      if (this.paperDefaultValidateConnectionMethod.apply(this.paper, args)) {
         const targetPortName = magnetT.attributes.port.value;
         const targetStep = cellViewT.model.step;
 

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -87,12 +87,12 @@ export default class Visualizer {
     this._step = null;
     this.clear();
 
-    const paperDefaultValidateConnectionMethod = this.paper.options.validateConnection;
+    const validateConnection = this.paper.options.validateConnection;
 
     this.paper.options.validateConnection = (cellViewS, magnetS, cellViewT, magnetT, end, linkView) => {
       const args = [cellViewS, magnetS, cellViewT, magnetT, end, linkView];
 
-      if (paperDefaultValidateConnectionMethod.apply(this.paper, args)) {
+      if (validateConnection.apply(this.paper, args)) {
         const targetPortName = magnetT.attributes.port.value;
         const targetStep = cellViewT.model.step;
 

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -86,6 +86,20 @@ export default class Visualizer {
     this._timer = null;
     this._step = null;
     this.clear();
+
+    this.paperDefaultValidateConnectionMethod = this.paper.options.validateConnection;
+
+    this.paper.options.validateConnection = (cellViewS, magnetS, cellViewT, magnetT, end, linkView) => {
+      const args = [cellViewS, magnetS, cellViewT, magnetT, end, linkView];
+
+      if (this.paperDefaultValidateConnectionMethod.call(this.paper, ...args)) {
+        const targetPortName = magnetT.attributes.port.value;
+        const targetStep = cellViewT.model.step;
+
+        return _.size(targetStep.i[targetPortName].inputs) === 0;
+      }
+      return false;
+    };
   }
 
   /**

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -87,12 +87,12 @@ export default class Visualizer {
     this._step = null;
     this.clear();
 
-    this.paperDefaultValidateConnectionMethod = this.paper.options.validateConnection;
+    const paperDefaultValidateConnectionMethod = this.paper.options.validateConnection;
 
     this.paper.options.validateConnection = (cellViewS, magnetS, cellViewT, magnetT, end, linkView) => {
       const args = [cellViewS, magnetS, cellViewT, magnetT, end, linkView];
 
-      if (this.paperDefaultValidateConnectionMethod.apply(this.paper, args)) {
+      if (paperDefaultValidateConnectionMethod.apply(this.paper, args)) {
         const targetPortName = magnetT.attributes.port.value;
         const targetStep = cellViewT.model.step;
 


### PR DESCRIPTION
## General idea
Currently Pipeline Builder does not take into account the links to the global workflow ports during new connection validation.This allows to bind multiple links into single input port which results in code generation errors. 
This pull request introduces improved ValidateConnection method:
Check the global port bindings (to prevent adding link if it is already bound to workflow port) and making Pipeline Builder able to show the available ports to bind while dragging the new link.

According to this new checking method it becomes untrivial to understand which port is available to be connected, by this way pull reques also introduce the GUI improvements as follow:

1. Empty Ports
![empty-view](http://pb.opensource.epam.com/data/emptyports.png)

2. Available to connect ports (during link dragging)
![available-view](http://pb.opensource.epam.com/data/availableports.png) 
 
## Changes
1. Visualizer.js - override the Paper validateConnection method to take into account the workflow binding
2. pipeline.scss - added styles for empty and available ports
3. Paper.js - switched on the markAvailable JointJS feature and updated the port validation condition
4. VisualStep.js - changed update method to support port style switching in case of situation 
