### PR TITLE
Updated travis config to enable the autodeploy to npm and demo stend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-    - EMAIL="aleksandr_sidoruk@epam.com" NPM_AUTH_TOKEN="e5fe6537-5536-4a7d-ac90-88d3601c4511" PACKAGE_NAME="pipeline-builder"
+    - EMAIL="aleksandr_sidoruk@epam.com" PACKAGE_NAME="pipeline-builder"
 language: node_js
 node_js: "6"
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,39 @@
+env:
+    - EMAIL="aleksandr_sidoruk@epam.com" NPM_AUTH_TOKEN="e5fe6537-5536-4a7d-ac90-88d3601c4511" PACKAGE_NAME="pipeline-builder-test"
 language: node_js
 node_js: "6"
 os: linux
 dist: trusty
+before_install: 
+    - |-
+          if [[ $TRAVIS_BRANCH == "dev" ]] || [[ $TRAVIS_BRANCH == "master" ]]; then
+              NPM_TAG="$(if [[ $TRAVIS_BRANCH == "dev" ]]; then echo "dev"; else echo "latest"; fi)"
+
+              LAST_PUBLISHED="$(npm view $PACKAGE_NAME@$NPM_TAG version)"
+              CURRENT_VERSION="$(npm version | grep -Po "(?<='$PACKAGE_NAME': ')[^']*")"
+
+              if [[ $LAST_PUBLISHED == $CURRENT_VERSION ]]; then
+                  echo "Version change required"
+                  exit 1; 
+              fi
+          fi
 install: 
     - yarn global add gulp-cli
     - yarn install
 script: gulp
 after_script: gulp test:coveralls
+deploy:
+    - provider: npm
+      email: $EMAIL
+      api_key: $NPM_AUTH_TOKEN
+      tag: dev
+      on:
+          branch: dev
+    - provider: npm
+      email: $EMAIL
+      api_key: $NPM_AUTH_TOKEN
+      tag: latest
+      on:
+          branch: master
+after_deploy:
+    - "curl \"http://35.164.165.183:8080/job/pipeline-wdl-builder-$TRAVIS_BRANCH/build?token=$JENKINS_SECRET_TOKEN\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-    - EMAIL="aleksandr_sidoruk@epam.com" NPM_AUTH_TOKEN="e5fe6537-5536-4a7d-ac90-88d3601c4511" PACKAGE_NAME="pipeline-builder-test"
+    - EMAIL="aleksandr_sidoruk@epam.com" NPM_AUTH_TOKEN="e5fe6537-5536-4a7d-ac90-88d3601c4511" PACKAGE_NAME="pipeline-builder"
 language: node_js
 node_js: "6"
 os: linux

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Pipeline Builder is a JavaScript library for visualizing and constructing bioinf
 
 ## Demo environment
 
-Example of a **Pipeline Builder** usage is available at [http://pb.opensource.epam.com](http://pb.opensource.epam.com)
+Example of a **Pipeline Builder** usage is available at [http://pb.opensource.epam.com](http://pb.opensource.epam.com) built on master branch and 
+[http://pb.opensource.epam.com:10000](http://pb.opensource.epam.com:10000) built on dev branch
 
 This demo application demonstrates major capabilities of a **Pipeline Builder**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.0-dev",
+  "version": "0.3.2-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",


### PR DESCRIPTION
## General idea
Currently pipeline developers have to commit the package to npm registry manually as well as manually updating the demo stend.

Proposed Travis CI configuration enable Travis npm autodeploy feature with desired parameters. 
Also the script written in after_deploy section calls the Jenkins API function that triggers rebuild of demo stend.

**NOTE** _that the proposed way requires to update version every commit or merge or rebase done in to the **dev** or **master** branch_

#### Travis CI workflow
![CIWorkflow](http://pb.opensource.epam.com/data/traviswf.png)
## Changes
**package.json** - updated _patch_ version
**.travis.yml** - added local and remote npm version difference checking to prevent the fail of deploying to npm, added deploy sections, added Jenkins API call method.
**NOTE** - _Travis CI have to be configured with JENKINS_SECRET_TOKEN and NPM_AUTH_TOKEN environment variables set to the known values_