### PR TITLE
Scatter iterative item access fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,14 @@ script: gulp
 after_script: gulp test:coveralls
 deploy:
     - provider: npm
+      skip_cleanup: true
       email: $EMAIL
       api_key: $NPM_AUTH_TOKEN
       tag: dev
       on:
           branch: dev
     - provider: npm
+      skip_cleanup: true
       email: $EMAIL
       api_key: $NPM_AUTH_TOKEN
       tag: latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.2-dev",
+  "version": "0.3.3-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",

--- a/src/parser/WDL/entities/WDLWorkflow.js
+++ b/src/parser/WDL/entities/WDLWorkflow.js
@@ -177,7 +177,12 @@ export default class WDLWorkflow {
       }
     } else if (declaration && nodeValue.str === 'identifier') {
       const portName = nodeValue.source_string;
-      step.i[declaration].bind(WDLWorkflow.groupNameResolver(parentStep, portName).i[portName]);
+      const portStep = WDLWorkflow.groupNameResolver(parentStep, portName);
+      if (_.isUndefined(portStep)) {
+        step.i[declaration].bind(portName);
+      } else {
+        step.i[declaration].bind(portStep.i[portName]);
+      }
     } else {
       const expression = extractExpression(nodeValue);
       step.i[declaration].bind(expression.string);

--- a/test/parser/WDL/entities/WDLWorkflowTest.js
+++ b/test/parser/WDL/entities/WDLWorkflowTest.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import WDLWorkflow from '../../../../src/parser/WDL/entities/WDLWorkflow';
 import WDLParserError from '../../../../src/parser/WDL/utils/utils';
+import Port from '../../../../src/model/Port';
 
 describe('parser/WDL/entities/WDLWorkflow', () => {
 
@@ -237,7 +238,46 @@ describe('parser/WDL/entities/WDLWorkflow', () => {
                           col: 6,
                         },
                         alias: null,
-                        body: null,
+                        body: {
+                          name: 'CallBody',
+                          attributes: {
+                            declarations: {
+                              list: [],
+                            },
+                            io: {
+                              list: [
+                                {
+                                  name: 'Inputs',
+                                  attributes: {
+                                    map: {
+                                      list: [
+                                        {
+                                          name: 'IOMapping',
+                                          attributes: {
+                                            key: {
+                                              id: 14,
+                                              str: 'identifier',
+                                              source_string: 'currSample',
+                                              line: 8,
+                                              col: 9,
+                                            },
+                                            value: {
+                                              id: 14,
+                                              str: 'identifier',
+                                              source_string: 'i',
+                                              line: 8,
+                                              col: 20,
+                                            },
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        },
                       },
                     },
                   ],
@@ -251,6 +291,9 @@ describe('parser/WDL/entities/WDLWorkflow', () => {
       const context = {
         actionMap: {
           bar: {
+            i: {
+              currSample: new Port('currSample'),
+            },
           },
         },
       };


### PR DESCRIPTION
## General idea

Last PullRequest related to scatter(if, while) support has been reviewed by github society and a couple of bugs were founded. This PR provides fix of bug related to accessing of scatter iterative item, for instance:
```
scatter (sample in inputSamples) {
    call HaplotypeCallerERC {
      input: 
        currentSample=sample, 
```
is not working cause **HaplotypeCallerERC** does not know what **sample** identifier is.

## Changes
Added code that catch the **undefined** value in name access resolving function and threat this exception as default binding.

**NOTE** - please let me know before PR will be merged. I have to select suitable package.json version for npm registry.