### PR TITLE
Empty wildcard outputs during generation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.3-dev",
+  "version": "0.3.4-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",

--- a/src/generator/WDL/entities/WorkflowGenerator.js
+++ b/src/generator/WDL/entities/WorkflowGenerator.js
@@ -243,7 +243,7 @@ export default class WorkflowGenerator {
 
       _.forEach(outputMappings, (val, key) => {
         if (key.indexOf('.') >= 0) {
-          res += `${this.buildPortValue(val)}${EOL}`;
+          res += `${DOUBLE_SCOPE_INDENT}${key}${EOL}`;
         } else {
           res += `${DOUBLE_SCOPE_INDENT}${val.desc.type} ${key} ${constants.EQ} ${this.buildPortValue(val)}${EOL}`;
         }


### PR DESCRIPTION
## General idea
The bug mentioned in [pipeline/issues#14](https://github.com/epam/pipeline-builder/issues/14) affects the outputs generated by pipeline builder when used [wildcard](https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#outputs) outputs kind. Currently pipeline builder gereate the empty lines where wildcards have to be appeared. This PR provide a solution of the problem.

## Changes
Fixed the generation logic near the wildcard output usage.

**NOTE** - please let me know before PR will be merged. I have to select suitable package.json version for npm registry.