### PR TITLE
Feature/graph layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.0-dev",
+  "version": "0.3.5-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",

--- a/src/visual/VisualGroup.js
+++ b/src/visual/VisualGroup.js
@@ -1,50 +1,47 @@
-import joint from 'jointjs';
+import _ from 'lodash';
+import VisualStep from './VisualStep';
 
-const cDefaultWidth = 100;
-const cMinHeight = 100;
+const cEmbedsPadding = 50;
 
 /** Class that provides graphical representation for the Group.
  * @private
  */
-export default class VisualGroup extends joint.shapes.devs.Model {
-  constructor(step, opts = {}) {
-    super({
-      position: {
-        x: (opts.x - cDefaultWidth / 2) || 0,
-        y: (opts.y - cMinHeight / 2) || 0,
-      },
+export default class VisualGroup extends VisualStep {
+  /**
+   * Creates new Group visual representation. Accepts all options for
+   * joint.shapes.dev.Model and Step and embeds padding values.
+   */
+  constructor(opts = {}) {
+    super(_.defaultsDeep(opts, {
       attrs: {
         '.label': {
-          text: step.type,
+          text: opts.step.type,
         },
       },
       type: 'VisualGroup',
-    });
-
-    this.step = step;
-    this.update();
+      embedsPadding: {
+        left: cEmbedsPadding,
+        right: cEmbedsPadding,
+        top: cEmbedsPadding,
+        bottom: cEmbedsPadding,
+      },
+    }));
   }
 
   /**
    * Updates visual step according to the model.
    */
   update() {
-    const step = this.step;
-
-    this.attr('.label', {
-      text: step.type,
-    });
+    super.update();
 
     if (this.graph) {
       this.fitEmbeds({
-        deep: true,
-        padding: {
-          left: 5,
-          right: 5,
-          top: 50,
-          bottom: 50,
-        },
+        padding: this.attributes.embedsPadding,
       });
     }
+  }
+
+  _getLabel() {
+    return this.step.type;
   }
 }

--- a/src/visual/VisualLink.js
+++ b/src/visual/VisualLink.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import joint from 'jointjs';
 
 /**
@@ -6,19 +7,12 @@ import joint from 'jointjs';
  */
 export default class VisualLink extends joint.shapes.devs.Link {
 
-  constructor(sourceId, sourcePort, targetId, targetPort, conn) {
-    super({
-      source: {
-        id: sourceId,
-        port: sourcePort,
-      },
-      target: {
-        id: targetId,
-        port: targetPort,
-      },
-    });
+  constructor(opts) {
+    super(_.defaultsDeep(opts, {
+      conn: null,
+    }));
     /** Connection from model. */
-    this.conn = conn;
+    this.conn = this.attributes.conn;
   }
 
   _check(name, port) {

--- a/src/visual/VisualStep.js
+++ b/src/visual/VisualStep.js
@@ -1,5 +1,5 @@
-import joint from 'jointjs';
 import _ from 'lodash';
+import joint from 'jointjs';
 
 const cDefaultWidth = 100;
 const cMinHeight = 100;
@@ -14,21 +14,30 @@ function findMaxLen(strList) {
  * @private
  */
 export default class VisualStep extends joint.shapes.devs.Model {
-  constructor(step, opts = {}) {
-    super({
+  /**
+   * Creates new Step visual representation. Accepts all options for
+   * joint.shapes.dev.Model and various custom parameters.
+   * @param {object=} opts - Action description.
+   * @param {Object.<string, Step>} opts.step - Step instance.
+   * @param {Object.<string, int>} [opts.x=0] - Center x coordinate.
+   * @param {Object.<string, int>} [opts.y=0] - Center y coordinate.
+   */
+  constructor(opts = { step: null, x: 0, y: 0 }) {
+    super(_.defaultsDeep(opts, {
       position: {
         x: (opts.x - cDefaultWidth / 2) || 0,
         y: (opts.y - cMinHeight / 2) || 0,
       },
       attrs: {
         '.label': {
-          text: step.name,
+          text: opts.step.name,
         },
       },
       type: 'VisualStep',
-    });
+      step: opts.step,
+    }));
 
-    this.step = step;
+    this.step = opts.step;
     this.update();
   }
 
@@ -40,7 +49,8 @@ export default class VisualStep extends joint.shapes.devs.Model {
     const inNames = Object.keys(step.i);
     const outNames = Object.keys(step.o);
     const height = Math.max(cMinHeight, cHeightPerPort * Math.max(inNames.length, outNames.length));
-    const width = Math.max(cDefaultWidth, step.name.length * cPixelPerSymbol);
+    const label = this._getLabel();
+    const width = Math.max(cDefaultWidth, label.length * cPixelPerSymbol);
     this.set({
       inPorts: inNames,
       outPorts: outNames,
@@ -50,7 +60,7 @@ export default class VisualStep extends joint.shapes.devs.Model {
       },
     });
     this.attr('.label', {
-      text: step.name,
+      text: label,
     });
 
     const ports = this.getPorts();
@@ -83,5 +93,9 @@ export default class VisualStep extends joint.shapes.devs.Model {
       bbox.width += leftOffset + rightOffset;
     }
     return bbox;
+  }
+
+  _getLabel() {
+    return this.step.name;
   }
 }

--- a/src/visual/VisualStep.js
+++ b/src/visual/VisualStep.js
@@ -3,7 +3,8 @@ import joint from 'jointjs';
 
 const cDefaultWidth = 100;
 const cMinHeight = 100;
-const cPixelPerSymbol = 15;
+const cPixelPerSymbol = 10;
+const cLabelMargin = 20;
 const cHeightPerPort = 50;
 
 function findMaxLen(strList) {
@@ -50,7 +51,7 @@ export default class VisualStep extends joint.shapes.devs.Model {
     const outNames = Object.keys(step.o);
     const height = Math.max(cMinHeight, cHeightPerPort * Math.max(inNames.length, outNames.length));
     const label = this._getLabel();
-    const width = Math.max(cDefaultWidth, label.length * cPixelPerSymbol);
+    const width = Math.max(cDefaultWidth, label.length * cPixelPerSymbol + 2 * cLabelMargin);
     this.set({
       inPorts: inNames,
       outPorts: outNames,

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -56,16 +56,22 @@ function createSubstituteCells(graph) {
   const newCells = [];
   let cellIdx = 0;
   _.forEach(newCellsMap, (newCell, key) => {
-    newCells[cellIdx] = newCell;
-    cellIdx += 1;
     const cellProto = graph.getCell(key);
-    newCell.proto = cellProto;
     if (newCell.isLink()) {
-      const source = newCellsMap[getHighestDescendant(cellProto.getSourceElement()).id];
-      const target = newCellsMap[getHighestDescendant(cellProto.getTargetElement()).id];
+      const protoSrc = cellProto.getSourceElement();
+      const protoDst = cellProto.getTargetElement();
+      if (protoDst.isEmbeddedIn(protoSrc, { deep: true }) ||
+          protoSrc.isEmbeddedIn(protoDst, { deep: true })) {
+        return;
+      }
+      const source = newCellsMap[getHighestDescendant(protoSrc).id];
+      const target = newCellsMap[getHighestDescendant(protoDst).id];
       newCell.get('source').id = source.id;
       newCell.get('target').id = target.id;
     }
+    newCells[cellIdx] = newCell;
+    cellIdx += 1;
+    newCell.proto = cellProto;
   });
 
   const gr = new joint.dia.Graph();

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -244,8 +244,9 @@ export default class Visualizer {
           x: this.paper.el.offsetWidth / 2,
           y: this.paper.el.offsetHeight / 2,
         });
+        opts.step = child;
         if (!visChild) {
-          visChild = _.isUndefined(child.type) ? new VisualStep(child, opts) : new VisualGroup(child, opts);
+          visChild = _.isUndefined(child.type) ? new VisualStep(opts) : new VisualGroup(opts);
 
           children[name] = visChild;
 

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -68,6 +68,12 @@ function createSubstituteCells(graph) {
       const target = newCellsMap[getHighestDescendant(protoDst).id];
       newCell.get('source').id = source.id;
       newCell.get('target').id = target.id;
+    } else {
+      const bbox = cellProto.getBBox();
+      newCell.set('size', {
+        width: bbox.width,
+        height: bbox.height,
+      });
     }
     newCells[cellIdx] = newCell;
     cellIdx += 1;
@@ -204,7 +210,7 @@ export default class Visualizer {
     const settings = {
       marginX: 100,
       marginY: 10,
-      rankSep: 230,
+      rankSep: 100,
       nodeSep: 80,
       rankDir: 'LR',
       setLinkVertices: false,
@@ -213,10 +219,6 @@ export default class Visualizer {
         element.proto.set('position', {
           x: glNode.x - glNode.width / 2,
           y: glNode.y - glNode.height / 2 });
-        element.proto.set('size', {
-          width: glNode.width,
-          height: glNode.height,
-        });
       }, // setVertices is ignored
     };
     joint.layout.DirectedGraph.layout(newCells, settings);
@@ -317,6 +319,7 @@ export default class Visualizer {
           this._graph.addCell(visChild);
           if (parent) {
             parent.embed(visChild);
+            parent.update();
           }
         } else {
           // it is essential to update links before the step!

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -68,7 +68,9 @@ function createSubstituteCells(graph) {
     }
   });
 
-  return newCells;
+  const gr = new joint.dia.Graph();
+  gr.addCells(newCells);
+  return gr;
 }
 
 /**
@@ -181,6 +183,7 @@ export default class Visualizer {
     this._step = step;
     this._update();
     this.layout();
+    this._update();// call update once more to invoke fitEmbeds
     this.zoom.fitToPage({ padding: 10, maxScale: 1 });
     this._timer = setInterval(() => this._update(), 30);
 
@@ -199,11 +202,15 @@ export default class Visualizer {
       nodeSep: 80,
       rankDir: 'LR',
       setLinkVertices: false,
-      resizeClusters: false,
+      resizeClusters: true,
       setPosition: (element, glNode) => {
         element.proto.set('position', {
           x: glNode.x - glNode.width / 2,
           y: glNode.y - glNode.height / 2 });
+        element.proto.set('size', {
+          width: glNode.width,
+          height: glNode.height,
+        });
       }, // setVertices is ignored
     };
     joint.layout.DirectedGraph.layout(newCells, settings);

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -180,8 +180,17 @@ export default class Visualizer {
           _.find(links, link => link.conn === conn) === undefined &&
           !srcIsGroup &&
           !dstIsGroup) {
-          const link = new VisualLink(
-            source.id, port.name, children[targetName].id, conn.to.name, conn);
+          const link = new VisualLink({
+            source: {
+              id: source.id,
+              port: port.name,
+            },
+            target: {
+              id: children[targetName].id,
+              port: conn.to.name,
+            },
+            conn,
+          });
           link.addTo(this._graph);
         }
       });


### PR DESCRIPTION
## General idea

This pull request provides an opportunity to layout compound graphs via jointjs. At the moment the layouting is limited - links to nodes that have embeds were prohibited. Such behavour blocks our features like group steps with their own inputs (e.g. scatter, conditional calls) mentioned in #9. Provided changes allow us to layout diverse compound graphs. 

## Changes

Refactored Visual Step, Group and Link to fit the Backbone model. This refactoring enabled the usage of standard clone methods and allowed the creation of temporary graph that has modified links. When that temporary graph is arranged, the layout is applied to the elements of the current graph.


**NOTE** - please let me know before PR will be merged. I have to select suitable package.json version for npm registry.