### PR TITLE
Added ports to the scatter and enable usage of variables into the scatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.8-dev",
+  "version": "0.3.9-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",

--- a/src/generator/WDL/entities/WorkflowGenerator.js
+++ b/src/generator/WDL/entities/WorkflowGenerator.js
@@ -203,11 +203,8 @@ export default class WorkflowGenerator {
 
     let res = '';
 
-    const item = child.i.condition;
-    if (_.isUndefined(item)) {
-      throw new Error('If statement model is not valid');
-    }
-    res += `${SCOPE_INDENT}${constants.IF} (${this.buildPortValue(item)}) ${constants.SCOPE_OPEN}${EOL}`;
+    const expression = child.action.data.expression;
+    res += `${SCOPE_INDENT}${constants.IF} (${expression}) ${constants.SCOPE_OPEN}${EOL}`;
 
     return this.genBodyCloser(res, child, prosessed);
   }
@@ -218,12 +215,8 @@ export default class WorkflowGenerator {
 
     let res = '';
 
-    const item = child.i.condition;
-    if (_.isUndefined(item)) {
-      throw new Error('If statement model is not valid');
-    }
-
-    res += `${SCOPE_INDENT}${constants.WHILE} (${this.buildPortValue(item)}) ${constants.SCOPE_OPEN}${EOL}`;
+    const expression = child.action.data.expression;
+    res += `${SCOPE_INDENT}${constants.WHILE} (${expression}) ${constants.SCOPE_OPEN}${EOL}`;
 
     return this.genBodyCloser(res, child, prosessed);
   }

--- a/src/generator/WDL/entities/WorkflowGenerator.js
+++ b/src/generator/WDL/entities/WorkflowGenerator.js
@@ -54,10 +54,7 @@ export default class WorkflowGenerator {
 
     let res = '';
 
-    if (!step.type) {
-      res += buildDeclarations(declarations, this.settings);
-    }
-
+    res += buildDeclarations(declarations, this.settings);
 
     for (let i = 0, size = _.size(children); i < size; ++i) {
       const childName = this.getNextOrderedChild(children, prosessed);
@@ -184,9 +181,18 @@ export default class WorkflowGenerator {
 
     let res = '';
 
-    const item = child.action.data.variable;
-    const collection = child.action.data.collection;
-    res += `${SCOPE_INDENT}${constants.SCATTER} (${item} ${constants.IN} ${collection}) {${EOL}`;
+    let item;
+    _.forEach(child.i, (val) => {
+      if (val.desc.type === 'ScatterItem') {
+        item = val;
+      }
+    });
+
+    if (_.isUndefined(item)) {
+      throw new Error('Scatter model is not valid');
+    }
+
+    res += `${SCOPE_INDENT}${constants.SCATTER} (${item.name} ${constants.IN} ${this.buildPortValue(item)}) {${EOL}`;
 
     return this.genBodyCloser(res, child, prosessed);
   }
@@ -197,8 +203,11 @@ export default class WorkflowGenerator {
 
     let res = '';
 
-    const expression = child.action.data.expression;
-    res += `${SCOPE_INDENT}${constants.IF} (${expression}) ${constants.SCOPE_OPEN}${EOL}`;
+    const item = child.i.condition;
+    if (_.isUndefined(item)) {
+      throw new Error('If statement model is not valid');
+    }
+    res += `${SCOPE_INDENT}${constants.IF} (${this.buildPortValue(item)}) ${constants.SCOPE_OPEN}${EOL}`;
 
     return this.genBodyCloser(res, child, prosessed);
   }
@@ -209,8 +218,12 @@ export default class WorkflowGenerator {
 
     let res = '';
 
-    const expression = child.action.data.expression;
-    res += `${SCOPE_INDENT}${constants.WHILE} (${expression}) ${constants.SCOPE_OPEN}${EOL}`;
+    const item = child.i.condition;
+    if (_.isUndefined(item)) {
+      throw new Error('If statement model is not valid');
+    }
+
+    res += `${SCOPE_INDENT}${constants.WHILE} (${this.buildPortValue(item)}) ${constants.SCOPE_OPEN}${EOL}`;
 
     return this.genBodyCloser(res, child, prosessed);
   }

--- a/src/generator/WDL/utils/utils.js
+++ b/src/generator/WDL/utils/utils.js
@@ -10,7 +10,9 @@ export function buildDeclarations(declarations, settings) { // eslint-disable-li
   let res = '';
 
   _.forEach(declarations, (decl, name) => {
-    res += `${SCOPE_INDENT}${decl.type} ${name}${decl.default ? buildDeclarationValue(decl.default) : ''}${EOL}`;
+    if (decl.type !== 'Condition' && decl.type !== 'ScatterItem') {
+      res += `${SCOPE_INDENT}${decl.type} ${name}${decl.default ? buildDeclarationValue(decl.default) : ''}${EOL}`;
+    }
   });
 
   return `${res}${EOL}`;

--- a/src/model/Group.js
+++ b/src/model/Group.js
@@ -27,9 +27,7 @@ class Group extends Step {
    * @param {object} [config={}] - Group configuration containing group meta information.
    */
   constructor(name, type, config = {}) {
-    if (!(config instanceof Action)) {
-      config.canHavePorts = false;
-    } else {
+    if (config instanceof Action) {
       throw new Error('Group could be created only using config object');
     }
 

--- a/src/parser/WDL/entities/WDLWorkflow.js
+++ b/src/parser/WDL/entities/WDLWorkflow.js
@@ -104,20 +104,12 @@ export default class WDLWorkflow {
    */
   parseIf(item, parent) {
     const opts = {
-      i: {
-        condition: {
-        },
+      data: {
+        expression: extractExpression(item.attributes.expression).string,
       },
     };
 
-    const condition = extractExpression(item.attributes.expression);
-
-    const port = WDLWorkflow.getPortForBinding(this.workflowStep, parent, condition);
-
-    opts.i.condition.type = 'Condition';
-
     const ifStatement = new Group(`if_${this.ifIndex}`, 'if', opts);
-    ifStatement.i.condition.bind(port);
 
     this.ifIndex += 1;
     parent.add(ifStatement);
@@ -132,21 +124,12 @@ export default class WDLWorkflow {
    */
   parseWhile(item, parent) {
     const opts = {
-      i: {
-        condition: {
-        },
+      data: {
+        expression: extractExpression(item.attributes.expression).string,
       },
     };
 
-    const condition = extractExpression(item.attributes.expression);
-
-    const port = WDLWorkflow.getPortForBinding(this.workflowStep, parent, condition);
-
-    opts.i.condition.type = 'Condition';
-    opts.i.condition.bind = port;
-
     const whileLoop = new Group(`whileloop_${this.loopIndex}`, 'whileloop', opts);
-    whileLoop.i.condition.bind(port);
 
     this.loopIndex += 1;
     parent.add(whileLoop);

--- a/src/parser/WDL/entities/WDLWorkflow.js
+++ b/src/parser/WDL/entities/WDLWorkflow.js
@@ -170,29 +170,10 @@ export default class WDLWorkflow {
 
   resolveBinding(node, step, parentStep) {
     const nodeValue = node.attributes.value;
-    const attributes = nodeValue.attributes;
-
-    const declaration = node.attributes.key ? node.attributes.key.source_string : undefined;
-
-    if (declaration && nodeValue.name === 'MemberAccess') {
-      const rhsPart = attributes && attributes.rhs ? attributes.rhs.source_string : '';
-      const lhsPart = attributes && attributes.lhs ? attributes.lhs.source_string : '';
-
-      const startStep = WDLWorkflow.findStepInStructureRecursively(this.workflowStep, lhsPart);
-      if (startStep && step) {
-        step.i[declaration].bind(startStep.o[rhsPart]);
-      }
-    } else if (declaration && nodeValue.str === 'identifier') {
-      const portName = nodeValue.source_string;
-      const portStep = WDLWorkflow.groupNameResolver(parentStep, portName);
-      if (_.isUndefined(portStep)) {
-        step.i[declaration].bind(portName);
-      } else {
-        step.i[declaration].bind(portStep.i[portName]);
-      }
-    } else {
+    const declaration = node.attributes.key.source_string;
+    if (declaration) {
       const expression = extractExpression(nodeValue);
-      step.i[declaration].bind(expression.string);
+      step.i[declaration].bind(WDLWorkflow.getPortForBinding(this.workflowStep, parentStep, expression));
     }
   }
 

--- a/src/visual/Paper.js
+++ b/src/visual/Paper.js
@@ -60,8 +60,7 @@ export default class Paper extends joint.dia.Paper {
           return result;
         };
         // source
-        if (!magnetS || !isSuitablePortClass(magnetS) ||
-          magnetS.getAttribute('port-group') !== 'out') {
+        if (!magnetS || !isSuitablePortClass(magnetS)) {
           return false;
         }
         // target

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -145,6 +145,14 @@ export default class Visualizer {
         const targetPortName = magnetT.attributes.port.value;
         const targetStep = cellViewT.model.step;
 
+        if (magnetS.getAttribute('port-group') === 'in') {
+          const sourceStep = cellViewS.model.step;
+
+          if (!_.has(sourceStep.children, targetStep.name)) {
+            return false;
+          }
+        }
+
         return _.size(targetStep.i[targetPortName].inputs) === 0;
       }
       return false;
@@ -365,7 +373,12 @@ export default class Visualizer {
         if (!targetChild || !sourceChild) {
           return;
         }
-        const sourcePort = sourceChild.o[link.get('source').port];
+
+        const srcPortName = link.get('source').port;
+        const sourcePort = this.paper.findViewByModel(link).sourceMagnet.getAttribute('port-group') === 'in' ?
+          sourceChild.i[srcPortName] :
+          sourceChild.o[srcPortName];
+
         const targetPort = targetChild.i[link.get('target').port];
         link.conn = targetPort.bind(sourcePort);
       }

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -147,8 +147,19 @@ export default class Visualizer {
 
         if (magnetS.getAttribute('port-group') === 'in') {
           const sourceStep = cellViewS.model.step;
+          const recursiveCheck = (step, childName) => {
+            let res = false;
+            _.forEach(step.children, (child) => {
+              if (child.name === childName || recursiveCheck(child, childName)) {
+                res = true;
+                return false;
+              }
+              return undefined;
+            });
+            return res;
+          };
 
-          if (!_.has(sourceStep.children, targetStep.name)) {
+          if (!recursiveCheck(sourceStep, targetStep.name)) {
             return false;
           }
         }

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -6,8 +6,6 @@ import VisualLink from './VisualLink';
 import VisualStep from './VisualStep';
 import VisualGroup from './VisualGroup';
 
-import Group from '../model/Group';
-
 import Zoom from './Zoom';
 
 // Code below is an official fix for Chrome 57 from JointJS
@@ -229,14 +227,9 @@ export default class Visualizer {
     const links = this._graph.getConnectedLinks(source);
     _.forEach(ports, (port) => {
       _.forEach(port.outputs, (conn) => {
-        const srcIsGroup = conn.from.step instanceof Group;
-        const dstIsGroup = conn.to.step instanceof Group;
-
         const targetName = conn.to.step.name;
         if (children[targetName] &&
-          _.find(links, link => link.conn === conn) === undefined &&
-          !srcIsGroup &&
-          !dstIsGroup) {
+          _.find(links, link => link.conn === conn) === undefined) {
           const link = new VisualLink({
             source: {
               id: source.id,

--- a/test/model/GroupTest.js
+++ b/test/model/GroupTest.js
@@ -36,7 +36,7 @@ describe('model/Group', () => {
       expect(new Group(name, type).type).to.equal(type);
     });
 
-    it('throws error when try to create with ports', () => {
+    it('allows to create with ports', () => {
       expect(() => new Group(name, type, config)).to.not.throw(Error);
     });
 

--- a/test/model/GroupTest.js
+++ b/test/model/GroupTest.js
@@ -37,7 +37,7 @@ describe('model/Group', () => {
     });
 
     it('throws error when try to create with ports', () => {
-      expect(() => new Group(name, type, config)).to.throw(Error);
+      expect(() => new Group(name, type, config)).to.not.throw(Error);
     });
 
     it('throws error when try to create with action', () => {

--- a/test/parser/WDL/entities/WDLWorkflowTest.js
+++ b/test/parser/WDL/entities/WDLWorkflowTest.js
@@ -301,6 +301,130 @@ describe('parser/WDL/entities/WDLWorkflow', () => {
       expect(workflow.workflowStep.children.scatter_0.type).to.equal('scatter');
     });
 
+    it('supports group level name resolving', () => {
+      const ast = {
+        name: {
+          id: 14,
+          str: 'identifier',
+          source_string: 'foo',
+          line: 2,
+          col: 10,
+        },
+        body: {
+          list: [
+            {
+              name: 'Declaration',
+              attributes: {
+                type: {
+                  id: 43,
+                  str: 'type',
+                  source_string: 'File',
+                  line: 3,
+                  col: 1,
+                },
+                name: {
+                  id: 14,
+                  str: 'identifier',
+                  source_string: 'wf_input',
+                  line: 3,
+                  col: 6,
+                },
+                expression: null,
+              },
+            },
+            {
+              name: 'Scatter',
+              attributes: {
+                item: {
+                  id: 14,
+                  str: 'identifier',
+                  source_string: 'i',
+                  line: 3,
+                  col: 11,
+                },
+                collection: {
+                  id: 14,
+                  str: 'string',
+                  source_string: '1234',
+                  line: 3,
+                  col: 16,
+                },
+                body: {
+                  list: [
+                    {
+                      name: 'Call',
+                      attributes: {
+                        task: {
+                          id: 11,
+                          str: 'fqn',
+                          source_string: 'bar',
+                          line: 3,
+                          col: 6,
+                        },
+                        alias: null,
+                        body: {
+                          name: 'CallBody',
+                          attributes: {
+                            declarations: {
+                              list: [],
+                            },
+                            io: {
+                              list: [
+                                {
+                                  name: 'Inputs',
+                                  attributes: {
+                                    map: {
+                                      list: [
+                                        {
+                                          name: 'IOMapping',
+                                          attributes: {
+                                            key: {
+                                              id: 14,
+                                              str: 'identifier',
+                                              source_string: 'currSample',
+                                              line: 8,
+                                              col: 9,
+                                            },
+                                            value: {
+                                              id: 14,
+                                              str: 'identifier',
+                                              source_string: 'wf_input',
+                                              line: 8,
+                                              col: 20,
+                                            },
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      const context = {
+        actionMap: {
+          bar: {
+            i: {
+              currSample: new Port('currSample'),
+            },
+          },
+        },
+      };
+      const workflow = new WDLWorkflow(ast, context);
+      expect(workflow.workflowStep.children.scatter_0.type).to.equal('scatter');
+    });
+
     it('supports loop', () => {
       const ast = {
         name: {
@@ -590,7 +714,6 @@ describe('parser/WDL/entities/WDLWorkflow', () => {
 
       expect(workflow.workflowStep.action.o).to.have.all.keys(['bar.out']);
     });
-
 
     it('supports workflow outputs with wildcard2', () => {
       const ast = {

--- a/test/parser/WDL/entities/WDLWorkflowTest.js
+++ b/test/parser/WDL/entities/WDLWorkflowTest.js
@@ -220,8 +220,8 @@ describe('parser/WDL/entities/WDLWorkflow', () => {
                 },
                 collection: {
                   id: 14,
-                  str: 'identifier',
-                  source_string: 'integers',
+                  str: 'string',
+                  source_string: '1234',
                   line: 3,
                   col: 16,
                 },


### PR DESCRIPTION
## General idea

Since [PR#20](https://github.com/epam/pipeline-builder/pull/20) was been merged it become possible to have a connections and ports in the scatter (if/while). This possibility make us able to propose solution for the following issues: #9 , #11 , #15 , and rewrite temporary fix for #16 , #21 . Currently pipeline-builder does not support the inputs in scatter(if/while) and does not show the scatter iteration item as a port. This pull request implements this features and hopefully fixes some bugs ( #15 , #16 , #21  ).

**In this PR it will look like:**
![GroupInputs](http://i.imgur.com/U1UZkcX.png)

## Changes

- Removed variable usege limitation for scatter 
- Enabled ports for scatter, if, while
- Enabled connections between scatter/if/while with other things
- Updated WDL generator code
- Updated tests due to the new scatter/if/while functionality.

## Scripts affected
- [ExtractSamHeadersWf_170107](https://raw.githubusercontent.com/broadinstitute/wdl/develop/scripts/broad_dsde_workflows/ExtractSamHeadersWf_170107.wdl)
- [RevertRGBamsToPairedFastQsWf_170107](https://raw.githubusercontent.com/broadinstitute/wdl/develop/scripts/broad_dsde_workflows/RevertRGBamsToPairedFastQsWf_170107.wdl)
- [ValidateBamsWf_170107](https://raw.githubusercontent.com/broadinstitute/wdl/develop/scripts/broad_dsde_workflows/ValidateBamsWf_170107.wdl)
- [PublicPairedSingleSampleWf_170412](https://raw.githubusercontent.com/broadinstitute/wdl/develop/scripts/broad_pipelines/PublicPairedSingleSampleWf_170412.wdl)