### PR TITLE
Bundle jointjs in pipeline-builder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,11 @@ module.exports = {
       property: 'pow',
       message: 'Use the exponentiation operator (**) instead.',
     }*/],
+    // We had to enable this in order to bundle jointjs
+    'import/no-extraneous-dependencies': ['error', {
+      devDependencies: true,
+      optionalDependencies: false,
+    }],
     'max-len': ['error', 120, 2, {
       ignoreUrls: true,
       ignoreComments: true,

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gulp-stylelint": "^3.9.0",
     "gulp-uglify": "^2.0.1",
     "gulp-util": "^3.0.8",
+    "jointjs": "^1.0.3",
     "jsdoc-export-default-interop": "^0.3.1",
     "minami": "^1.1.1",
     "mocha": "^3.2.0",
@@ -81,7 +82,8 @@
     "open": "^0.0.5",
     "rollup": "^0.41.4",
     "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-commonjs": "^7.0.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
     "run-sequence": "^1.2.2",
     "sass-loader": "^6.0.2",
@@ -95,7 +97,6 @@
     "yargs": "^6.6.0"
   },
   "dependencies": {
-    "jointjs": "^1.0.3",
     "lodash": "^4.17.4"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.5-dev",
+  "version": "0.3.7-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,8 +23,8 @@ export default {
     rollupPluginCommonJS({
       include: ['./node_modules/**', './src/parser/WDL/hermes/wdl_parser.js'],
       namedExports: {
-        './node_modules/jointjs/dist/joint.min.js': [ 'joint', 'V', 'g' ],
-      }
+        './node_modules/jointjs/dist/joint.min.js': ['joint', 'V', 'g'],
+      },
     }),
     rollupPluginBabel({
       babelrc: false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@
 import rollupPluginBabel from 'rollup-plugin-babel';
 import rollupPluginCommonJS from 'rollup-plugin-commonjs';
 import rollupPluginReplace from 'rollup-plugin-replace';
+import rollupPluginNodeResolve from 'rollup-plugin-node-resolve';
 
 const version = require('./version');
 const packageJson = require('./package.json');
@@ -13,14 +14,17 @@ const copyright = `${packageJson.description} v${version.combined} Copyright (c)
 export default {
   entry: './src/pipeline.js',
   banner: `/*! ${copyright} */`,
-  external: ['lodash', 'jointjs'],
+  external: ['lodash'],
   globals: {
     lodash: '_',
-    jointjs: 'joint',
   },
   plugins: [
+    rollupPluginNodeResolve(),
     rollupPluginCommonJS({
-      include: './src/parser/WDL/hermes/wdl_parser.js',
+      include: ['./node_modules/**', './src/parser/WDL/hermes/wdl_parser.js'],
+      namedExports: {
+        './node_modules/jointjs/dist/joint.min.js': [ 'joint', 'V', 'g' ],
+      }
     }),
     rollupPluginBabel({
       babelrc: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,6 +743,12 @@ brorand@^1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.0.7.tgz#6677fa5e4901bdbf9c9ec2a748e28dca407a9bfc"
 
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
 browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
@@ -827,7 +833,7 @@ bufferstreams@^1.1.1:
   dependencies:
     readable-stream "^2.0.2"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -2975,6 +2981,10 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
@@ -4997,15 +5007,24 @@ rollup-plugin-babel@^2.7.1:
     object-assign "^4.1.0"
     rollup-pluginutils "^1.5.0"
 
-rollup-plugin-commonjs@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-7.0.0.tgz#510762d5c423c761cd16d8e8451715b39f0ceb08"
+rollup-plugin-commonjs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz#98b1589bfe32a6c0f67790b60c0b499972afed89"
   dependencies:
     acorn "^4.0.1"
     estree-walker "^0.3.0"
     magic-string "^0.19.0"
     resolve "^1.1.7"
-    rollup-pluginutils "^1.5.1"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
 
 rollup-plugin-replace@^1.1.1:
   version "1.1.1"
@@ -5015,12 +5034,19 @@ rollup-plugin-replace@^1.1.1:
     minimatch "^3.0.2"
     rollup-pluginutils "^1.5.0"
 
-rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1:
+rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
 
 rollup@^0.41.4:
   version "0.41.4"


### PR DESCRIPTION
## General idea

This pull request bundles jointjs into our librray. These changes are imposed by the lodash version conflicts with jointjs which is stuck on the 
3.10.1 and pipeline, where we use the latest version. Therefore, we decided to embed jointjs to our package.

## Changes

Changed rollup config and removed jointjs from dependencies.