### PR TITLE
Improve embedding update mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-builder",
-  "version": "0.3.9-dev",
+  "version": "0.3.10-dev",
   "description": "Pipeline Builder",
   "main": "dist/pipeline.js",
   "jsnext:main": "dist/pipeline.module.js",

--- a/src/visual/VisualGroup.js
+++ b/src/visual/VisualGroup.js
@@ -29,11 +29,9 @@ export default class VisualGroup extends VisualStep {
   }
 
   /**
-   * Updates visual step according to the model.
+   * Call fit embeds with default params.
    */
-  update() {
-    super.update();
-
+  fit() {
     if (this.graph) {
       this.fitEmbeds({
         padding: this.attributes.embedsPadding,

--- a/src/visual/VisualStep.js
+++ b/src/visual/VisualStep.js
@@ -49,9 +49,10 @@ export default class VisualStep extends joint.shapes.devs.Model {
     const step = this.step;
     const inNames = Object.keys(step.i);
     const outNames = Object.keys(step.o);
-    const height = Math.max(cMinHeight, cHeightPerPort * Math.max(inNames.length, outNames.length));
+    const size = this.attributes.size;
+    const height = Math.max(cMinHeight, cHeightPerPort * Math.max(inNames.length, outNames.length), size.height);
     const label = this._getLabel();
-    const width = Math.max(cDefaultWidth, label.length * cPixelPerSymbol + 2 * cLabelMargin);
+    const width = Math.max(cDefaultWidth, label.length * cPixelPerSymbol + 2 * cLabelMargin, size.width);
     this.set({
       inPorts: inNames,
       outPorts: outNames,

--- a/src/visual/Visualizer.js
+++ b/src/visual/Visualizer.js
@@ -168,6 +168,15 @@ export default class Visualizer {
       }
       return false;
     };
+
+    graph.on('change:position', (cell) => {
+      let parentId = cell.get('parent');
+      while (parentId) {
+        const parent = graph.getCell(parentId);
+        parent.fit();
+        parentId = parent.get('parent');
+      }
+    });
   }
 
   /**
@@ -331,6 +340,7 @@ export default class Visualizer {
           this._graph.addCell(visChild);
           if (parent) {
             parent.embed(visChild);
+            parent.fit();
             parent.update();
           }
         } else {


### PR DESCRIPTION
## General idea

At the moment it appears that there are excessive calls of fitEmbeds() for groups. This behaviour result  in too frequent updates of the contents and some visual lags when dragging child objects. 

## Changes

Now group steps are only updated when thier childrens's positions are being changed.