### PR TITLE
Version selection improvement on travis CI side

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ os: linux
 dist: trusty
 before_install: 
     - |-
-          if [[ $TRAVIS_BRANCH == "dev" ]] || [[ $TRAVIS_BRANCH == "master" ]]; then
-              NPM_TAG="$(if [[ $TRAVIS_BRANCH == "dev" ]]; then echo "dev"; else echo "latest"; fi)"
-
-              LAST_PUBLISHED="$(npm view $PACKAGE_NAME@$NPM_TAG version)"
-              CURRENT_VERSION="$(npm version | grep -Po "(?<='$PACKAGE_NAME': ')[^']*")"
+          CURRENT_VERSION="$(npm version | grep -Po "(?<='$PACKAGE_NAME': ')[^']*")"
+          if [[ $TRAVIS_BRANCH == "master" ]]; then
+              LAST_PUBLISHED="$(npm view $PACKAGE_NAME@latest version)"
 
               if [[ $LAST_PUBLISHED == $CURRENT_VERSION ]]; then
                   echo "Version change required"
@@ -22,6 +20,13 @@ install:
     - yarn install
 script: gulp
 after_script: gulp test:coveralls
+before_deploy:
+    - |-
+          if [[ $TRAVIS_BRANCH == "dev" ]]; then
+              VERSION_TO_PUBLISH=$CURRENT_VERSION.$TRAVIS_BUILD_NUMBER
+              echo "$VERSION_TO_PUBLISH"
+              npm --no-git-tag-version version $VERSION_TO_PUBLISH
+          fi
 deploy:
     - provider: npm
       skip_cleanup: true


### PR DESCRIPTION
## General idea
Currently on pipeline-builder project developers have to select the suitable version manually after every pull request on dev branch to make possible NPM autodeploy process. This PR introduces the way to automaticaly version update in moment of deploying to NPM by adding the TraviCI build number to the end of NPM version. 

BTW this changes makes developers able to not care about version selection.

## Changes

- removed version check before build process for `dev` branch
- added version update before deploy to NPM registry only for `dev`

**NOTE**: main version part changes are still being under developers controll for merges and commits to the `master` branch