### PR TITLE
Generator string escaping fix

### DIFF
--- a/src/generator/WDL/utils/utils.js
+++ b/src/generator/WDL/utils/utils.js
@@ -1,8 +1,28 @@
 import _ from 'lodash';
 import * as constants from '../constants';
 
+export function escapeWDLString(src) {
+  const escapes = {
+    '\\\\': '\\\\',
+    '\\\\0': '\\\\0',
+    '\\\\n': '\\\\n',
+    '\\\\r': '\\\\r',
+    '\\\\b': '\\\\b',
+    '\\\\t': '\\\\t',
+    '\\\\f': '\\\\f',
+    '\\\\a': '\\\\a',
+    '\\\\v': '\\\\v'
+  };
+
+  _.forEach(escapes, (val, key) => {
+    src = src.replace(new RegExp(key, 'g'), escapes[key]);
+  });
+
+  return src;
+}
+
 export function buildDeclarations(declarations, settings) { // eslint-disable-line import/prefer-default-export
-  const buildDeclarationValue = value => ` ${constants.EQ} ${value.toString()}`;
+  const buildDeclarationValue = value => ` ${constants.EQ} ${escapeWDLString(value.toString())}`;
 
   const EOL = settings.getValue('style.eol');
   const SCOPE_INDENT = settings.getValue('style.scope_indent');

--- a/src/generator/WDL/utils/utils.js
+++ b/src/generator/WDL/utils/utils.js
@@ -11,7 +11,7 @@ export function escapeWDLString(src) {
     '\\\\t': '\\\\t',
     '\\\\f': '\\\\f',
     '\\\\a': '\\\\a',
-    '\\\\v': '\\\\v'
+    '\\\\v': '\\\\v',
   };
 
   _.forEach(escapes, (val, key) => {

--- a/src/generator/WDL/utils/utils.js
+++ b/src/generator/WDL/utils/utils.js
@@ -1,28 +1,8 @@
 import _ from 'lodash';
 import * as constants from '../constants';
 
-export function escapeWDLString(src) {
-  const escapes = {
-    '\\\\': '\\\\',
-    '\\\\0': '\\\\0',
-    '\\\\n': '\\\\n',
-    '\\\\r': '\\\\r',
-    '\\\\b': '\\\\b',
-    '\\\\t': '\\\\t',
-    '\\\\f': '\\\\f',
-    '\\\\a': '\\\\a',
-    '\\\\v': '\\\\v',
-  };
-
-  _.forEach(escapes, (val, key) => {
-    src = src.replace(new RegExp(key, 'g'), escapes[key]);
-  });
-
-  return src;
-}
-
 export function buildDeclarations(declarations, settings) { // eslint-disable-line import/prefer-default-export
-  const buildDeclarationValue = value => ` ${constants.EQ} ${escapeWDLString(value.toString())}`;
+  const buildDeclarationValue = value => ` ${constants.EQ} ${value.toString()}`;
 
   const EOL = settings.getValue('style.eol');
   const SCOPE_INDENT = settings.getValue('style.scope_indent');

--- a/src/parser/WDL/utils/utils.js
+++ b/src/parser/WDL/utils/utils.js
@@ -164,7 +164,7 @@ const processors = {
   },
   default: (scope) => {
     if (scope.ast.str === 'string') {
-      scope.res.string = `"${scope.ast.source_string}"`;
+      scope.res.string = `"${JSON.stringify(scope.ast.source_string).slice(1, -1)}"`;
       scope.res.type = 'string';
     } else {
       scope.res.string = scope.ast.source_string;


### PR DESCRIPTION
## General idea
By default WDl JS parser supports the symbols escaping in the strings and during the parsing characters become unescaped so them have to be escaped back at the generation but currently pipeline-builder does not do it.

For example the following script cound not be build twice cause of syntax error after first generation attempt:
```
workflow main {
   scatter (pair in [(1, 2), (3, 4), (5, 6)]) {
      String sub_strip_path = fastq_directory_path
      String sub_strip_extension = "\\.read.\\.fq" + "$"

      call foo {
         input:
            pair = pair,
            in = sub(sub(pair[0], sub_strip_path, ""), sub_strip_extension, ""),
      }
   }
}

task foo {
   String in
   Array[Int] pair
}
```

## Changes
Added escaping function simmilar to grammar.hgr escaping